### PR TITLE
Added missing logentry-review lines to nl.json

### DIFF
--- a/i18n/flaggedrevs/nl.json
+++ b/i18n/flaggedrevs/nl.json
@@ -12,7 +12,8 @@
 			"Tkinkhorst",
 			"Mainframe98",
 			"Mar(c)",
-			"Romaine"
+			"Romaine",
+			"lassesix"
 		]
 	},
 	"action-review": "versies als \"gecontroleerd\" te markeren",
@@ -45,6 +46,8 @@
 	"group-autoreview": "Automatische controleurs",
 	"group-autoreview-member": "{{GENDER:$1|automatische controleur}}",
 	"grouppage-autoreview": "{{ns:project}}:Automatische controleurs",
+	"logentry-review-approve": "$1 heeft een versie van $3 gecontroleerd",
+	"logentry-review-unapprove":  "$1 heeft een versie van $3 ongeldig gemaakt"
 	"revreview-hist-draft": "ongecontroleerde versie",
 	"revreview-hist-pending": "wacht op controle",
 	"revreview-hist-quality": "kwaliteitsversie",

--- a/i18n/flaggedrevs/nl.json
+++ b/i18n/flaggedrevs/nl.json
@@ -47,7 +47,7 @@
 	"group-autoreview-member": "{{GENDER:$1|automatische controleur}}",
 	"grouppage-autoreview": "{{ns:project}}:Automatische controleurs",
 	"logentry-review-approve": "$1 heeft een versie van $3 gecontroleerd",
-	"logentry-review-unapprove":  "$1 heeft een versie van $3 ongeldig gemaakt"
+	"logentry-review-unapprove":  "$1 heeft een versie van $3 ongeldig gemaakt",
 	"revreview-hist-draft": "ongecontroleerde versie",
 	"revreview-hist-pending": "wacht op controle",
 	"revreview-hist-quality": "kwaliteitsversie",


### PR DESCRIPTION
Added missing translations of "logentry-review-approve" and "logentry-review-unapprove" to nl.json.